### PR TITLE
feat: add PROFILE environment variable as alternative to --profile flag

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -96,7 +96,7 @@ module.exports = function (webpackEnv) {
   // Variable used for enabling profiling in Production
   // passed into alias object. Uses a flag if passed into the build command
   const isEnvProductionProfile =
-    isEnvProduction && process.argv.includes('--profile');
+    isEnvProduction && (process.argv.includes('--profile') || process.env.PROFILE !== 'false');
 
   // We will provide `paths.publicUrlOrPath` to our app
   // as %PUBLIC_URL% in `index.html` and `process.env.PUBLIC_URL` in JavaScript.


### PR DESCRIPTION
I think this small addition would be very useful to make it easier to conditionally build profiling-enabled builds on CI environments.

Rather than having to redefine the installation script it's enough to set the `PROFILE` environment variable to `true`.

Basically, with this, I could have a `.env.development` with `PROFILE=true` to automatically make my development (not local) environment builds  include the profiling build of React DOM